### PR TITLE
Implement basic HEGA wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # HEGA
+
+This repository provides a simple implementation of the **Hybrid Embedding-to-Generation Architecture (HEGA)** using the Hugging Face `mistralai/Mistral-7B-v0.1` model.
+
+The `HEGAModel` splits the model into two parts:
+
+- **Embedding phase** (`0 ~ l_cut`): used to encode texts and build a FAISS index.
+- **Generation phase** (`l_cut+1 ~`): generates responses conditioned on the prompt and retrieved texts.
+
+Users can configure the number of layers (`l_cut`), the number of documents to retrieve (`k`), and whether the embedding part should also be used during generation.
+
+## Example
+
+```bash
+pip install -r requirements.txt
+python scripts/hega_example.py --prompt "Tell me about transformers" --l_cut 16 --k 3
+```
+
+Add `--use_embedding_for_generation` to continue generation from the embedding layers.

--- a/hega/model.py
+++ b/hega/model.py
@@ -1,0 +1,75 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import faiss
+from typing import List
+
+
+class HEGAModel:
+    """Hybrid Embedding-to-Generation Architecture."""
+
+    def __init__(self, model_name: str = "mistralai/Mistral-7B-v0.1", l_cut: int = 16,
+                 use_embedding_for_generation: bool = True, k: int = 4, device: str | None = None):
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32
+        ).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.l_cut = l_cut
+        self.k = k
+        self.use_embedding_for_generation = use_embedding_for_generation
+        self.index: faiss.IndexFlatL2 | None = None
+        self.texts: List[str] = []
+
+    def _forward_until(self, hidden_states: torch.Tensor, end_layer: int) -> torch.Tensor:
+        for i in range(end_layer):
+            layer = self.model.model.layers[i]
+            hidden_states = layer(hidden_states)[0]
+        return hidden_states
+
+    def encode(self, texts: List[str]) -> torch.Tensor:
+        inputs = self.tokenizer(texts, return_tensors="pt", padding=True, truncation=True).to(self.device)
+        hidden_states = self.model.model.embed_tokens(inputs.input_ids)
+        hidden_states = self._forward_until(hidden_states, self.l_cut)
+        pooled = hidden_states.mean(dim=1)
+        return pooled.detach().cpu()
+
+    def index_texts(self, texts: List[str]):
+        self.texts.extend(texts)
+        embeddings = self.encode(texts).numpy()
+        dim = embeddings.shape[1]
+        if self.index is None:
+            self.index = faiss.IndexFlatL2(dim)
+        self.index.add(embeddings)
+
+    def retrieve(self, query: str) -> List[str]:
+        if self.index is None:
+            return []
+        query_emb = self.encode([query]).numpy()
+        distances, indices = self.index.search(query_emb, self.k)
+        return [self.texts[i] for i in indices[0] if i < len(self.texts)]
+
+    def _forward_from(self, hidden_states: torch.Tensor, start_layer: int) -> torch.Tensor:
+        for i in range(start_layer, len(self.model.model.layers)):
+            layer = self.model.model.layers[i]
+            hidden_states = layer(hidden_states)[0]
+        hidden_states = self.model.model.norm(hidden_states)
+        logits = self.model.lm_head(hidden_states)
+        return logits
+
+    def generate(self, prompt: str, max_new_tokens: int = 50) -> str:
+        retrieved_texts = self.retrieve(prompt)
+        context = prompt
+        if retrieved_texts:
+            context += "\n" + "\n".join(retrieved_texts)
+        inputs = self.tokenizer(context, return_tensors="pt").to(self.device)
+        if self.use_embedding_for_generation:
+            hidden_states = self.model.model.embed_tokens(inputs.input_ids)
+            hidden_states = self._forward_until(hidden_states, self.l_cut)
+            logits = self._forward_from(hidden_states, self.l_cut)
+            generated = self.model.generate(inputs_embeds=logits, max_new_tokens=max_new_tokens,
+                                            pad_token_id=self.tokenizer.eos_token_id)
+        else:
+            generated = self.model.generate(**inputs, max_new_tokens=max_new_tokens,
+                                            pad_token_id=self.tokenizer.eos_token_id)
+        return self.tokenizer.decode(generated[0], skip_special_tokens=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch
+transformers
+faiss-cpu

--- a/scripts/hega_example.py
+++ b/scripts/hega_example.py
@@ -1,0 +1,30 @@
+import argparse
+from hega.model import HEGAModel
+
+
+def main():
+    parser = argparse.ArgumentParser(description="HEGA example")
+    parser.add_argument("--model", type=str, default="mistralai/Mistral-7B-v0.1")
+    parser.add_argument("--l_cut", type=int, default=16)
+    parser.add_argument("--k", type=int, default=4)
+    parser.add_argument("--use_embedding_for_generation", action="store_true")
+    parser.add_argument("--prompt", type=str, required=True)
+    args = parser.parse_args()
+
+    hega = HEGAModel(model_name=args.model, l_cut=args.l_cut, k=args.k,
+                      use_embedding_for_generation=args.use_embedding_for_generation)
+
+    # Example index (toy)
+    hega.index_texts([
+        "This is a sample document about machine learning.",
+        "Another document describes the transformers library.",
+        "More texts can be added to build a larger retrieval index."
+    ])
+
+    output = hega.generate(args.prompt)
+    print("\n=== Generated ===\n")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `HEGAModel` that splits Mistral 7B into embedding and generation layers
- add example script showing indexing and generation
- document usage in README
- add minimal requirements list

## Testing
- `python -m py_compile hega/model.py scripts/hega_example.py`


------
https://chatgpt.com/codex/tasks/task_e_684ab598e028832b90f0e73ed695623e